### PR TITLE
chore: update TypeScript config

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
-  "extends": "expo/tsconfig.base",
   "compilerOptions": {
+    "jsx": "react-native",
+    "lib": ["es2017"],
     "strict": true,
     "paths": {
       "@/*": [


### PR DESCRIPTION
## Summary
- drop Expo tsconfig base extension
- specify React Native JSX mode and target ES2017 libs

## Testing
- `npx tsc -p . --noEmit` *(fails: Cannot find module 'react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68c4515bc7208327b6e50af86dd26324